### PR TITLE
Remove italicising of logical operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daybreak-theme",
   "author": "Mike Mali <michaeltdmali@gmail.com> (http://twitter.com/mtdmali)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/mtdmali/daybreak-theme"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daybreak-theme",
   "author": "Mike Mali <michaeltdmali@gmail.com> (http://twitter.com/mtdmali)",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/mtdmali/daybreak-theme"

--- a/themes/daybreak-color-theme.json
+++ b/themes/daybreak-color-theme.json
@@ -207,17 +207,17 @@
       "scope": [
         "keyword.operator.new",
         "keyword.operator.expression",
-        "keyword.operator.logical",
         "keyword.operator.delete"
       ],
-      "settings": { "foreground": "#B877DBE6", "fontStyle": "" }
+      "settings": { "foreground": "#B877DBE6", "fontStyle": "italic" }
     },
     {
       "name": "Special operators",
       "scope": [
         "keyword.operator.logical",
+        "keyword.operator.comparison"
       ],
-      "settings": { "fontStyle": "" }
+      "settings": { "foreground": "#BBBBBB", "fontStyle": "" }
     },
     {
       "name": "Units",

--- a/themes/daybreak-color-theme.json
+++ b/themes/daybreak-color-theme.json
@@ -210,7 +210,14 @@
         "keyword.operator.logical",
         "keyword.operator.delete"
       ],
-      "settings": { "foreground": "#B877DBE6" }
+      "settings": { "foreground": "#B877DBE6", "fontStyle": "" }
+    },
+    {
+      "name": "Special operators",
+      "scope": [
+        "keyword.operator.logical",
+      ],
+      "settings": { "fontStyle": "" }
     },
     {
       "name": "Units",


### PR DESCRIPTION
Italicising logical operators can cause the logical OR operator (||) to
have the appearance of the start of comment, which may cause confusion.